### PR TITLE
Switch arg parsing to clap-derive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,12 +39,13 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "3.0.0-rc.9"
+version = "3.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7843ae7a539bef687e018bf9edf7e87728024b29d02b0f8409726be8880ae1a"
+checksum = "71c47df61d9e16dc010b55dba1952a57d8c215dbb533fd13cdd13369aac73b1c"
 dependencies = [
  "atty",
  "bitflags",
+ "clap_derive",
  "indexmap",
  "lazy_static",
  "os_str_bytes",
@@ -54,12 +55,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "clap_generate"
-version = "3.0.0-rc.9"
+name = "clap_complete"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c85d334a8eeb937cb285ab86e9eb141a3639ab8b0eb9b20677edbd00ccdda8f5"
+checksum = "df6f3613c0a3cddfd78b41b10203eb322cb29b600cbdf808a7d3db95691b8e25"
 dependencies = [
  "clap",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3aab4734e083b809aaf5794e14e756d1c798d2c69c7f7de7a09a2f5214993c1"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -123,6 +137,12 @@ name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+
+[[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
@@ -220,6 +240,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -267,7 +311,7 @@ name = "rsv"
 version = "1.3.3"
 dependencies = [
  "clap",
- "clap_generate",
+ "clap_complete",
  "serde",
  "serde_derive",
  "serde_yaml",
@@ -380,15 +424,21 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.14.2"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,8 @@ serde = "1.0.132"
 serde_derive = "1.0.132"
 serde_yaml = "0.8.23"
 sudo = { version = "0.6.0", optional = true }
-clap = { version = "3.0.0-rc.9", features = ["cargo"] }
-clap_generate = "3.0.0-rc.9"
+clap = { version = "3.1", features = ["cargo", "derive"] }
+clap_complete = "3.1"
 
 [features]
 default = ["auto_sudo"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,44 +3,30 @@ mod config;
 mod run;
 mod sv;
 
-use clap::App;
-use clap_generate::{
-    generate,
-    generators::{Bash, Elvish, Fish, Zsh},
-    Generator,
-};
+use args::{Cli, Command};
+use clap::{crate_name, IntoApp, Parser};
+use clap_complete::Shell;
 
 fn main() {
-    let app = args::get_cli().get_matches();
+    let cli = Cli::parse();
 
-    // Run generator command if desired
-    if let Some(generator) = app.value_of("generator") {
-        generate_completions(generator);
+    // Generate completion
+    if let Command::Completion { shell } = cli.command {
+        generate_completion(shell);
         return;
     }
 
-    match run::run(&app) {
+    match run::run(cli) {
         Ok(s) => print!("{}", s),
         Err(e) => eprintln!("An error occured: {}", e),
     }
 }
 
-fn generate_completions(generator: &str) {
-    let mut app = args::get_cli();
-    match generator {
-        "bash" => print_completions(&mut app, Bash),
-        "elvish" => print_completions(&mut app, Elvish),
-        "fish" => print_completions(&mut app, Fish),
-        "zsh" => print_completions(&mut app, Zsh),
-        _ => println!("Unknown generator"),
-    }
-}
-
-fn print_completions<G: Generator>(app: &mut App, generator: G) {
-    generate::<G, _>(
-        generator,
-        app,
-        app.get_name().to_string(),
+fn generate_completion(shell: Shell) {
+    clap_complete::generate(
+        shell,
+        &mut Cli::command(),
+        crate_name!(),
         &mut std::io::stdout(),
-    );
+    )
 }

--- a/src/sv/cmdtype.rs
+++ b/src/sv/cmdtype.rs
@@ -1,3 +1,5 @@
+use crate::args::Command;
+
 /// All available Commands
 /// for runsv
 #[derive(Debug)]
@@ -66,6 +68,28 @@ impl From<&str> for SvCommandType {
             "alarm" => SvCommandType::Alarm,
             "interrupt" => SvCommandType::Interrupt,
             "kill" => SvCommandType::Kill,
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl From<&Command> for SvCommandType {
+    fn from(command: &Command) -> Self {
+        match command {
+            Command::Enable { .. } => SvCommandType::Enable,
+            Command::Disable { .. } => SvCommandType::Disable,
+            Command::Start { .. } => SvCommandType::Up,
+            Command::Stop { .. } => SvCommandType::Down,
+            Command::Restart { .. } => SvCommandType::Restart,
+            Command::Status { .. } => SvCommandType::Status,
+            Command::Once { .. } => SvCommandType::Once,
+            Command::Pause { .. } => SvCommandType::Pause,
+            Command::Continue { .. } => SvCommandType::Continue,
+            Command::Term { .. } => SvCommandType::Terminate,
+            Command::Hup { .. } => SvCommandType::Hangup,
+            Command::Alarm { .. } => SvCommandType::Alarm,
+            Command::Interrupt { .. } => SvCommandType::Interrupt,
+            Command::Kill { .. } => SvCommandType::Kill,
             _ => unreachable!(),
         }
     }


### PR DESCRIPTION
Switches clap parsing from the Builder API to the Derive API to reduce boilerplate code.

Important: this PR introduces backwards incompatible changes in the CLI interface:

* Instead of the `--generate` argument, there's now a separate `rsv completion` subcommand, e.g. `rsv completion zsh`.
* For usage clarity, `rsv list --down` gains a short variant `rsv list -d`, while the short flag for `rsv list --disabled` is now `rsv list -D`

Let me know if you disagree with these changes.

I noticed the `rsv list --all` flag is unused, maybe it could be removed altogether?